### PR TITLE
Allow unpkg.com as `connect-src`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@
       img-src 'self' *;
       script-src 'self' https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
       style-src 'self' 'unsafe-inline' https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
-      connect-src 'self' https://cdn.kernvalley.us https://api.kernvalley.us;
+      connect-src 'self' https://cdn.kernvalley.us https://api.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
       worker-src: 'self';
       font-src 'self' https://cdn.kernvalley.us;
       media-src 'none';

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,13 +22,12 @@
       default-src 'self';
       base-uri 'self';
       img-src 'self' *;
-      script-src 'self' https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
+      script-src 'self' mox-extension: https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
       style-src 'self' 'unsafe-inline' https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
       connect-src 'self' https://cdn.kernvalley.us https://api.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
       worker-src: 'self';
       font-src 'self' https://cdn.kernvalley.us;
       media-src 'none';
-      child-src 'self';
       object-src: 'none';
       manifest-src 'self';
       form-action 'self';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maps.kernvalley.us",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Maps for the Kern River Valley",
   "config": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 'use strict';
 /*eslint no-undef: 0*/
-/* 2019-10-22T10:21 */
+/* 2019-11-20T11:31 */
 self.importScripts('/sw-config.js');
 
 self.addEventListener('install', async event => {

--- a/sw-config.js
+++ b/sw-config.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: 0 */
 const config = {
-	version: location.hostname === 'localhost' ? new Date().toISOString() : '1.0.0',
+	version: location.hostname === 'localhost' ? new Date().toISOString() : '1.0.1',
 	stale: [
 		'/',
 		'/js/index.js',


### PR DESCRIPTION
Allowing this *should* fix network errors, as blocking this URL blocks all `fetch` in service workers.

Will check on deploy preview.