### PR TITLE
Allow map tiles in `connect-src`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@
       img-src 'self' *;
       script-src 'self' mox-extension: https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
       style-src 'self' 'unsafe-inline' https://cdn.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
-      connect-src 'self' https://cdn.kernvalley.us https://api.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/;
+      connect-src 'self' https://cdn.kernvalley.us https://api.kernvalley.us https://unpkg.com/leaflet@1.6.0/dist/ https://maps.wikimedia.org/;
       worker-src: 'self';
       font-src 'self' https://cdn.kernvalley.us;
       media-src 'none';

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,7 +32,7 @@
       manifest-src 'self';
       form-action 'self';
       reflected-xss block;
-      report-uri https://api.kernvalley.us/Errors/CSP/
+      report-uri https://api.kernvalley.us/Errors/CSP/;
       block-all-mixed-content;
       upgrade-insecure-requests;
       disown-opener;'''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "static-template",
-  "version": "1.0.0",
+  "name": "maps.kernvalley.us",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maps.kernvalley.us",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Maps for the Kern River Valley",
   "config": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 'use strict';
 /*eslint no-undef: 0*/
-/* 2019-11-20T11:31 */
+/* 2019-11-20T11:45 */
 self.importScripts('/sw-config.js');
 
 self.addEventListener('install', async event => {

--- a/sw-config.js
+++ b/sw-config.js
@@ -53,6 +53,7 @@ const config = {
 		'https://cdn.kernvalley.us/css/animate.css/animate.css',
 		'https://unpkg.com/leaflet@1.6.0/dist/leaflet.css',
 		'/img/icons.svg',
+		'https://cdn.kernvalley.us/img/octicons/organization.svg',
 		'/img/apple-touch-icon.png',
 		'/img/icon-192.png',
 		'/img/favicon.svg',

--- a/sw-config.js
+++ b/sw-config.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: 0 */
 const config = {
-	version: location.hostname === 'localhost' ? new Date().toISOString() : '1.0.1',
+	version: location.hostname === 'localhost' ? new Date().toISOString() : '1.0.2',
 	stale: [
 		'/',
 		'/js/index.js',


### PR DESCRIPTION
This is necessary when working from service worker for adding new resources, allowing them to be cache-able. 