### PR TITLE
Add support for `find` in embedded maps

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -27,6 +27,7 @@ Promise.all([
 		zoom: parseInt(params.get('zoom')),
 		watch: parseInt(params.get('watch')),
 		zoomControl: params.has('zoomcontrol'),
+		find: parseInt(params.get('find')),
 	});
 
 	document.body.append(map);


### PR DESCRIPTION
If `find=:int` is passed, pass into constructor to center on user